### PR TITLE
Pass OpenAI config as param

### DIFF
--- a/lib/instructor/adapters/openai.ex
+++ b/lib/instructor/adapters/openai.ex
@@ -5,13 +5,14 @@ defmodule Instructor.Adapters.OpenAI do
   @behaviour Instructor.Adapter
 
   @impl true
-  def chat_completion(params, config \\ %OpenAI.Config{}) do
+  def chat_completion(params) do
     # Peel off instructor only parameters
     # TODO: Maybe refactor this? we'll see
     {_, params} = Keyword.pop(params, :response_model)
     {_, params} = Keyword.pop(params, :validation_context)
     {_, params} = Keyword.pop(params, :max_retries)
     {_, params} = Keyword.pop(params, :mode)
+    {config, params} = Keyword.pop(params, :config, %OpenAI.Config{})
 
     OpenAI.chat_completion(params, config)
   end


### PR DESCRIPTION
Allow `OpenAI.Config` struct to be passed as keyword param in `Instructor.chat_completion`. Still defaults to an empty struct as per the previous behavior. 