### PR TITLE
Test fixes

### DIFF
--- a/lib/instructor/json_schema.ex
+++ b/lib/instructor/json_schema.ex
@@ -107,7 +107,7 @@ defmodule Instructor.JSONSchema do
       |> Enum.into(%{})
 
     properties = Map.merge(properties, associations)
-    required = Map.keys(properties)
+    required = Map.keys(properties) |> Enum.sort()
     title = title_for(ecto_schema)
 
     associated_schemas =

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -158,19 +158,19 @@ defmodule JSONSchemaTest do
         }
       },
       "required" => [
-        "integer",
-        "date",
-        "float",
-        "time",
-        "string",
-        "map",
-        "boolean",
         "array",
+        "boolean",
+        "date",
         "decimal",
+        "float",
+        "integer",
+        "map",
         "map_two",
-        "time_usec",
         "naive_datetime",
         "naive_datetime_usec",
+        "string",
+        "time",
+        "time_usec",
         "utc_datetime",
         "utc_datetime_usec"
       ],
@@ -266,7 +266,7 @@ defmodule JSONSchemaTest do
           "child" => %{"$ref" => "#/$defs/JSONSchemaTest.Child"},
           "id" => %{"title" => "id", "type" => "integer"}
         },
-        "required" => ["id", "child"],
+        "required" => ["child", "id"],
         "title" => "JSONSchemaTest.Demo",
         "type" => "object"
       }
@@ -317,7 +317,7 @@ defmodule JSONSchemaTest do
         },
         "id" => %{"title" => "id", "type" => "integer"}
       },
-      "required" => ["id", "children"],
+      "required" => ["children", "id"],
       "title" => "JSONSchemaTest.Demo",
       "type" => "object"
     }
@@ -361,7 +361,7 @@ defmodule JSONSchemaTest do
               "type" => "array"
             }
           },
-          "required" => ["name", "children"],
+          "required" => ["children", "name"],
           "type" => "object"
         }
       },


### PR DESCRIPTION
On my platform (Mac M1), I had failures on a number of tests while running just `mix test`.

Since I want to contribute a bit to this project, this was a good first issue :smile:.

The root cause is that `Map.keys` order is not guaranteed (see references below).

This PR fixes a couple of those (the ones happening on my machine) - note that I didn't run the full suite, only `mix test` basic suite.

### References

A couple of references on that topic:

https://hexdocs.pm/elixir/keywords-and-maps.html

> Compared to keyword lists, we can already see two differences:
> - Maps allow any value as a key.
> - Maps' keys do not follow any ordering.

And also: 

https://fly.io/phoenix-files/taking-control-of-map-sort-order-in-elixir/

> If you’ve recently upgraded to Elixir 1.14.4 and OTP 26, you may have noticed that map keys are no longer showing in a predictable order

