### PR TITLE
Add first GitHub CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - setup-ci
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    env:
+      MIX_ENV: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pair:
+              elixir: "1.11"
+              otp: "21.3"
+          - pair:
+              elixir: "1.16"
+              otp: "26.2"
+            lint: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{matrix.pair.elixir}}-${{matrix.pair.otp}}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - run: mix deps.get --check-locked
+
+      - run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - run: mix deps.unlock --check-unused
+        if: ${{ matrix.lint }}
+
+      - run: mix deps.compile
+
+      - run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+
+      - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - thbar:setup-ci
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
+    types:
+      - *
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - thbar:setup-ci
 
 jobs:
   test:


### PR DESCRIPTION
Taking a stab at:
- #14 

I looked for fresh inspiration and decided to try out this:
- https://github.com/dashbitco/mox/blob/master/.github/workflows/ci.yml

Connected tests are not currently running (which is a good start), due to how the tests are configured:

https://github.com/thmsmlr/instructor_ex/blob/617ee4c813f1189abde76130c7a636fe2a1a0c99/test/test_helper.exs#L3-L4

The configured matrix tests:
1. The most recent Elixir/OTP combination, with linting activated
2. An older combination for compatibility check

Creating the PR so that we can try things out.

### TODOs

- [ ] Make the workflow run
- [ ] Adapt the matrix if needed
- [ ] Update readme/issues

