### PR TITLE
Add params for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ instructor-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+*.DS_Store
+llama.log

--- a/lib/instructor.ex
+++ b/lib/instructor.ex
@@ -32,6 +32,8 @@ defmodule Instructor do
     * `:mode` - The mode to use when parsing the response, :tools, :json, :md_json (defaults to `:tools`), generally speaking you don't need to change this unless you are not using OpenAI.
     * `:max_retries` - The maximum number of times to retry the LLM call if it fails, or does not pass validations.
                        (defaults to `0`)
+    * `:inspect_request?` -`IO.inspect` the request before sending to the LLM, useful for debugging (defaults to `false`).
+    * `:inspect_response?` -`IO.inspect` the response from the LLM before processing, useful for debugging (defaults to `false`).
 
   ## Examples
 


### PR DESCRIPTION
This PR would add two new params to `chat_completion`, namely `inspect_request?` and `inspect_response?` which has the effect of calling `IO.inspect` on the request, just before sending it to the LLM, or on the response before processing it. 

I needed this for debugging, so I think others might find it useful. 

@thmsmlr How does this sit with you? An alternative might be to pass in a callback, in stead of setting a flag, and then the user can log / inspect or do whatever they want in the callback. Any thought?

