### PR TITLE
Warn on missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ config :instructor, adapter: Instructor.Adapters.Llamacpp
 config :instructor, :llamacpp,
     chat_template: :mistral_instruct,
     api_url: "http://localhost:8080/completion"
-````
-
-<!-- Docs -->
+```
 
 ## Installation
 
@@ -120,6 +118,8 @@ def project do
   ]
 end
 ```
+
+<!-- Docs -->
 
 ## TODO
 

--- a/lib/instructor/json_schema.ex
+++ b/lib/instructor/json_schema.ex
@@ -1,4 +1,5 @@
 defmodule Instructor.JSONSchema do
+  require Logger
   defguardp is_ecto_schema(mod) when is_atom(mod)
   defguardp is_ecto_types(types) when is_map(types)
 
@@ -48,7 +49,8 @@ defmodule Instructor.JSONSchema do
   end
 
   defp fetch_ecto_schema_doc(ecto_schema) when is_ecto_schema(ecto_schema) do
-    ecto_schema_struct_literal = "%#{title_for(ecto_schema)}{}"
+    title = title_for(ecto_schema)
+    ecto_schema_struct_literal = "%#{title}{}"
 
     case Code.fetch_docs(ecto_schema) do
       {_, _, _, _, _, _, docs} ->
@@ -61,7 +63,11 @@ defmodule Instructor.JSONSchema do
             false
         end)
 
-      {:error, _} ->
+      {:error, reason} ->
+        Logger.warning(
+          "Error fetching documentation for #{title}. The JSON schema for this model might be incomplete.\n#{inspect(reason)}"
+        )
+
         nil
     end
   end

--- a/lib/instructor/json_schema.ex
+++ b/lib/instructor/json_schema.ex
@@ -49,8 +49,7 @@ defmodule Instructor.JSONSchema do
   end
 
   defp fetch_ecto_schema_doc(ecto_schema) when is_ecto_schema(ecto_schema) do
-    title = title_for(ecto_schema)
-    ecto_schema_struct_literal = "%#{title}{}"
+    ecto_schema_struct_literal = "%#{title_for(ecto_schema)}{}"
 
     case Code.fetch_docs(ecto_schema) do
       {_, _, _, _, _, _, docs} ->
@@ -65,7 +64,7 @@ defmodule Instructor.JSONSchema do
 
       {:error, reason} ->
         Logger.warning(
-          "Error fetching documentation for #{title}. The JSON schema for this model might be incomplete.\n#{inspect(reason)}"
+          "Error fetching documentation for #{ecto_schema}. The JSON schema for this model might be incomplete.\n#{inspect(reason)}"
         )
 
         nil


### PR DESCRIPTION
closes #47 

In this PR we emit a warning when the docs are missing for an ecto schema.

Also, the note in the README about configuring releases, is added the docs.