### PR TITLE
Return raw errors

### DIFF
--- a/lib/instructor.ex
+++ b/lib/instructor.ex
@@ -436,10 +436,10 @@ defmodule Instructor do
       {:ok, changeset |> Ecto.Changeset.apply_changes()}
     else
       {:llm, {:error, error}} ->
-        {:error, "LLM Adapter Error: #{inspect(error)}"}
+        {:error, :adapter_error, error}
 
       {:valid_json, {:error, error}} ->
-        {:error, "Invalid JSON returned from LLM: #{inspect(error)}"}
+        {:error, :invalid_json, error}
 
       {:validation, changeset, response} ->
         if max_retries > 0 do


### PR DESCRIPTION
This is just a proposal, but basically I have a reasonably complex workflow that requires a lot of calls to the OAI API. Because of this, I'm running into rate limit issues that I would like to handle by adding some retries with backoff functionality. I can just match on `{:error, _}`, but having the raw errors would make things a bit easier because I can handle the specific case where the API returns a rate-limit exceeded error and do the retries in that case. Thoughts?