### PR TITLE
Add support for issuing chat completions against Azure OpenAI

### DIFF
--- a/pages/azure_openai.md
+++ b/pages/azure_openai.md
@@ -1,0 +1,17 @@
+# Azure OpenAI
+
+Configure your project like so to [issue requests against Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions):
+
+```elixir
+config: [
+  instructor: [
+    adapter: Instructor.Adapters.OpenAI,
+    openai: [
+      auth_mode: :api_key,
+      api_key: System.fetch_env!("AZURE_API_KEY"),
+      api_url: "[AZURE_OPENAI_RESOURCE_ENDPOINT]",
+      api_path: "/openai/deployments/[AZURE_OPENAI_DEPLOYMENT_NAME]/chat/completions?api-version=2024-02-01"
+    ]
+  ]
+]
+```


### PR DESCRIPTION
One reason for wanting to use InstructorEx with Azure OpenAI is due to Azure's ability to deploy a model to a specific region to comply with data sovereignty regulations.

This change introduces the notion of `auth_mode` (`:bearer` or `:api_key`) in order to select Azure API key style of authentication or OpenAI's `bearer` token. In addition we wanted to override the path to the chat completion service via config.

Please let me know if this needs more work and many things for making this package available.