### PR TITLE
fix(Llamacpp): `Llamacpp.url/0` doesn't return the url that was set in config

### DIFF
--- a/lib/instructor/adapters/llamacpp.ex
+++ b/lib/instructor/adapters/llamacpp.ex
@@ -149,8 +149,8 @@ defmodule Instructor.Adapters.Llamacpp do
     "<s>#{prompt}"
   end
 
-  defp url() do
-    Keyword.get(config(), :url, "http://localhost:8080/completion")
+  def url() do
+    Keyword.get(config(), :api_url, "http://localhost:8080/completion")
   end
 
   defp chat_template() do

--- a/test/instructor_test.exs
+++ b/test/instructor_test.exs
@@ -21,6 +21,9 @@ defmodule InstructorTest do
 
       :openai_mock ->
         Application.put_env(:instructor, :adapter, InstructorTest.MockOpenAI)
+
+      nil ->
+        :ok
     end
   end
 
@@ -418,5 +421,10 @@ defmodule InstructorTest do
       assert [ok: %{name: "Thomas"}, ok: %{name: "Jason"}] =
                result |> Enum.to_list()
     end
+  end
+
+  test "Llamacpp adapter gets the url from :api_url in config" do
+    Application.put_env(:instructor, :llamacpp, api_url: "http://1.2.3.4:8080/completion")
+    assert "http://1.2.3.4:8080/completion" == Instructor.Adapters.Llamacpp.url()
   end
 end


### PR DESCRIPTION
`LLamacpp` adapter uses the wrong config field to get the API url. To create a unit test around `LLamacpp.url/0` I made the function public. I've also added a `nil` case in the test `setup` to be able to run a test without adapter (at the moment tests with Llamacpp adapter are excluded).