### PR TITLE
Fix system prompt doubling on retry

### DIFF
--- a/lib/instructor.ex
+++ b/lib/instructor.ex
@@ -558,7 +558,14 @@ defmodule Instructor do
           """
         }
 
-        messages = [sys_message | messages]
+        # do not re-add the system message if it's already there
+        messages =
+          if Enum.any?(messages, fn message -> message == sys_message end) do
+            messages
+          else
+            [sys_message | messages]
+          end
+
 
         case mode do
           :md_json ->


### PR DESCRIPTION
I'm unsure if this is affecting anyone else, but for me, I get doubling of the system prompt on retries. This prevents it by checking if it's already in the messages context before trying to add it.