### PR TITLE
[Gemini adapter] Support message content with image and video URLs

### DIFF
--- a/lib/instructor/adapters/gemini.ex
+++ b/lib/instructor/adapters/gemini.ex
@@ -57,8 +57,24 @@ defmodule Instructor.Adapters.Gemini do
         %{role: "assistant", content: content}, {system_instructions, history} ->
           {system_instructions, [%{role: "model", parts: [%{text: content}]} | history]}
 
-        %{role: "user", content: content}, {system_instructions, history} ->
+        %{role: "user", content: content}, {system_instructions, history}
+        when is_binary(content) ->
           {system_instructions, [%{role: "user", parts: [%{text: content}]} | history]}
+
+        %{role: "user", content: content}, {system_instructions, history} ->
+          parts =
+            Enum.map(content, fn
+              %{type: "text", text: text} ->
+                %{text: text}
+
+              %{type: "image_url", image_url: %{url: url, mime_type: mime_type}} ->
+                %{file_data: %{mime_type: mime_type, file_uri: url}}
+
+              %{type: "video_url", video_url: %{url: url, mime_type: mime_type}} ->
+                %{file_data: %{mime_type: mime_type, file_uri: url}}
+            end)
+
+          {system_instructions, [%{role: "user", parts: parts} | history]}
 
         %{role: "system", content: content}, {system_instructions, history} ->
           part = %{text: content}
@@ -106,6 +122,13 @@ defmodule Instructor.Adapters.Gemini do
           params
           |> Map.put(:generationConfig, generation_config)
           |> Map.delete(:response_format)
+          |> Map.put(:safetySettings, [
+            %{category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_NONE"},
+            %{category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE"},
+            %{category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE"},
+            %{category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_NONE"},
+            %{category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "BLOCK_NONE"}
+          ])
 
         %{tools: tools} ->
           tools = [


### PR DESCRIPTION
Fixes #80

The Gemini API [expects you to upload images/videos separately](https://ai.google.dev/gemini-api/docs/vision?lang=rest#upload-image). That feels outside of the scope of Instructor, so I've avoided adding that in this PR.

## Example usage:

```elixir
defmodule VideoDesc do
  use Ecto.Schema

  @primary_key false
  embedded_schema do
    field(:video_description, :string)
    field(:oscar_winning_moment, :boolean)
  end
end

Instructor.chat_completion(
  mode: :json_schema,
  model: "gemini-1.5-flash",
  response_model: VideoDesc,
  messages: [
    %{
      role: "user", 
      content: [
        %{
          type: "video_url",
          video_url: %{
            url: "https://generativelanguage.googleapis.com/v1beta/files/d2ngu357dmfx",
            mime_type: "video/mp4"
          }
        },
        %{
          type: "text",
          text: "What's going on in this video?"
        }
      ]
    }
  ]
)
```