### PR TITLE
Feat: add JsonFixer module to fix some invalid JSON content, before p…

### DIFF
--- a/lib/instructor/adapters/openai.ex
+++ b/lib/instructor/adapters/openai.ex
@@ -154,18 +154,22 @@ defmodule Instructor.Adapters.OpenAI do
        do: Jason.decode(args)
 
   defp parse_response_for_mode(:md_json, %{"choices" => [%{"message" => %{"content" => content}}]}),
-       do: Jason.decode(content)
+       do: decode_message_content(content)
 
   defp parse_response_for_mode(:json, %{"choices" => [%{"message" => %{"content" => content}}]}),
-    do: Jason.decode(content)
+    do: decode_message_content(content)
 
   defp parse_response_for_mode(:json_schema, %{
          "choices" => [%{"message" => %{"content" => content}}]
        }),
-       do: Jason.decode(content)
+       do: decode_message_content(content)
 
   defp parse_response_for_mode(mode, response) do
     {:error, "Unsupported OpenAI mode #{mode} with response #{inspect(response)}"}
+  end
+
+  defp decode_message_content(content) do
+    Instructor.JsonFixer.run(content)
   end
 
   defp parse_stream_chunk_for_mode(:md_json, %{"choices" => [%{"delta" => %{"content" => chunk}}]}),

--- a/lib/instructor/json_fixer.ex
+++ b/lib/instructor/json_fixer.ex
@@ -1,0 +1,20 @@
+defmodule Instructor.JsonFixer do
+  @moduledoc """
+  Some models return slightly malformed JSON. This module attempts to fix that.
+  """
+
+  def run(content) do
+    content
+    |> unwrap_json_code_block()
+    |> Jason.decode()
+  end
+
+  defp unwrap_json_code_block(str) when is_binary(str) do
+    regex = ~r/^```json\s*\n(.*?)\n```$/ms
+
+    case Regex.run(regex, str, capture: :all_but_first) do
+      [json] -> String.trim(json)
+      _ -> str
+    end
+  end
+end


### PR DESCRIPTION
…arsing it.

Problem: 
- some LLM models respond with slightly invalid JSON, like ```json\n{"a": 1}```
- this trips off the JSON parser

Solution: 
- if there are backticks around our expected JSON, trim it first, before parsing
- we fix it in the OpenAI Adapter, since most other adapters piggy-back on it